### PR TITLE
docs: cite published QST paper instead of arXiv preprint

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,8 +8,8 @@ Welcome to the qdesignoptimizer's documentation!
 Reference
 =========
 
-| A technical paper describing the functionality and giving examples is in preparation. 
-| Eriksson, et al., *"Automated, physics-guided, multi-parameter design optimization for superconducting quantum devices"*, arXiv:2508.18027 [quant-ph], 2025.
+| A technical paper describing the functionality and giving examples has been published.
+| Eriksson, et al., *"QDesignOptimizer based on ANMod: an automated, physics-guided, multi-parameter design optimizer for superconducting quantum devices"*, `Quantum Science and Technology 11, 035024 (2026) <https://doi.org/10.1088/2058-9565/ae7ab6>`_.
 | Please refer to this publication when citing the ``qdesignoptimizer``.
 
 .. toctree::

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python 3.10.*
+  - python >=3.11,<3.13
   - pip
   - poetry 2.0.*

--- a/src/qdesignoptimizer/design_analysis.py
+++ b/src/qdesignoptimizer/design_analysis.py
@@ -658,7 +658,7 @@ class DesignAnalysis:
                     "Design variable update failed, but is expected for a partitioned optimization until all parameters have been simulated."
                 )
                 updated_design_vars = deepcopy(self.design.variables)
-                minimization_results: list[dict] = []
+                minimization_results = []
         log.info("Updated_design_vars%s", dict_log_format(updated_design_vars))
         self.update_var(updated_design_vars, {})
 
@@ -904,6 +904,11 @@ def merge_partitioned_simulation(
     all_design_vars_to_update = {}
     all_target_params = set()
 
+    system_optimized_params = state_to_fetch_from.system_optimized_params
+    assert (
+        system_optimized_params is not None
+    ), "state_to_fetch_from.system_optimized_params must be initialized before merging."
+
     #  1 prepare design_variables and system_optimized_params to update
     for target in opt_targets:
         if target.target_param_type == NONLIN:
@@ -916,9 +921,9 @@ def merge_partitioned_simulation(
         all_target_params.add(param_to_update)
 
         if param_to_update in include_param_in_update:
-            all_params_to_update[param_to_update] = (
-                state_to_fetch_from.system_optimized_params[param_to_update]
-            )
+            all_params_to_update[param_to_update] = system_optimized_params[
+                param_to_update
+            ]
             all_design_vars_to_update[target.design_var] = (
                 state_to_fetch_from.design.variables[target.design_var]
             )

--- a/src/qdesignoptimizer/sim_plot_progress.py
+++ b/src/qdesignoptimizer/sim_plot_progress.py
@@ -300,10 +300,10 @@ class DataExtractor:
             ]
             if not filtered:
                 return [], []
-            x_values_filtered, y_values_filtered = zip(*filtered)
+            x_tuple, y_tuple = zip(*filtered)
 
-            x_values_filtered = list(x_values_filtered)
-            y_values_filtered = list(y_values_filtered)
+            x_values_filtered = list(x_tuple)
+            y_values_filtered = list(y_tuple)
 
             if sort_by_x and x_values_filtered:
                 sorted_pairs = sorted(zip(x_values_filtered, y_values_filtered))
@@ -403,8 +403,9 @@ class OptimizationPlotter:
             x_label: Custom x-axis label (overrides config)
             y_label: Custom y-axis label (overrides config)
         """
-        if ax.get_legend() is not None:
-            ax.get_legend().remove()
+        legend = ax.get_legend()
+        if legend is not None:
+            legend.remove()
 
         ax.set_xlabel(x_label if x_label is not None else config.get_x_label())
 

--- a/src/qdesignoptimizer/sim_plot_progress.py
+++ b/src/qdesignoptimizer/sim_plot_progress.py
@@ -48,6 +48,12 @@ class UnitEnum(str, Enum):
     NS = "ns"
     ARB = "arb."
 
+    def __str__(self) -> str:
+        # Return the display string (e.g. "Hz") rather than the member repr.
+        # On Python >=3.11 the str/Enum mixin no longer formats as its value,
+        # so f"{unit}" would otherwise render as "UnitEnum.HZ".
+        return self.value
+
 
 @dataclass
 class OptPltSet:

--- a/src/qdesignoptimizer/utils/names_parameters.py
+++ b/src/qdesignoptimizer/utils/names_parameters.py
@@ -14,7 +14,7 @@ FREQ: Literal["freq"] = "freq"
 KAPPA: Literal["kappa"] = "kappa"
 CHARGE_LINE_LIMITED_T1: Literal["charge_line_limited_t1"] = "charge_line_limited_t1"
 NONLIN: Literal["nonlinearity"] = "nonlinearity"
-CAPACITANCE = "capacitance"
+CAPACITANCE: Literal["capacitance"] = "capacitance"
 """ dict: Maps branch to capacitance matrix elements in capacitance matrix simulation.
     Capacitance matrix elements are in femto Farads (fF).
 


### PR DESCRIPTION
## Summary
- Replace the arXiv:2508.18027 preprint reference with the published version in *Quantum Science and Technology* **11**, 035024 (2026), with a DOI link to https://doi.org/10.1088/2058-9565/ae7ab6
- Update the title to match the published article (it differs from the preprint title)
- Update the surrounding text: the paper "has been published" rather than "is in preparation"

## Notes
- The published author list is: Axel M Eriksson, Lukas J Splitthoff, Harsh Vardhan Upadhyay, Pietro Campana, Oscar Lundström, Niranjan Pittan Narendiran, Kunal Helambe, Linus Andersson, Simone Gasparinetti. The citation keeps the existing "Eriksson, et al." short form.
- Docs are deployed to GitHub Pages via `.github/workflows/deploy_docs.yml`, which only publishes when the change is on `main`, so the live docs will update automatically once this PR is merged.